### PR TITLE
Feat: add front matter feature

### DIFF
--- a/M2MD/M2MD.m
+++ b/M2MD/M2MD.m
@@ -71,19 +71,20 @@ MDExport // Options = {
       
   "BoxesToStringType" -> $BoxesToStringType, (*whatever ExportPacket supports*)  
   
-  "MDElementTemplates"-> Automatic (* _String | template_ *)
+  "MDElementTemplates"-> Automatic, (* _String | template_ *)
+  "FrontMatter" -> <||>
 }
 
 
 MDExport[path_String , obj_, patt : OptionsPattern[]]:=
 Export[
   path
-, M2MD[obj
+, AddFrontMatter[M2MD[obj
   , patt (*will overwrite that path if needed*)
   , "ImagesExportURL" -> FileNameJoin[{FileNameDrop @ ExpandFileName @ path, "img"}]
   , "ImagesFetchURL"  -> "Relative"
   
-  ] 
+  ], Lookup[patt,"FrontMatter"] ]
 , "Text"
 , CharacterEncoding -> "UTF8"
 ]
@@ -109,7 +110,7 @@ MDEnvironment[___, OptionsPattern[] ]:= Function[
 ]
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*LoadDefinitions*)
 
 
@@ -194,7 +195,7 @@ M2MD[ cell : Cell[_, style_, ___], opt : OptionsPattern[] ] := M2MD[style, cell,
 (*Convertions*)
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*style rules*)
 
 
@@ -254,7 +255,7 @@ ItemStyleQ      = StringContainsQ["item", IgnoreCase -> True]
 ItemLevel = StringCount[#, "sub", IgnoreCase -> True]&
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*content rules*)
 
 
@@ -285,7 +286,26 @@ BoxesToMDString[boxes_, inlineCell_:True, opt : OptionsPattern[]]:= parseData[bo
 
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
+(*AddFrontMatter*)
+
+
+AddFrontMatter[markdownString_String,frontMatter_Association:<||>]:=Module[{frontMatterString,resultString},
+If[AssociationQ[frontMatter] && Length[frontMatter] != 0,
+(*Convert the nested association to JSON format*)
+frontMatterJSON=ExportString[frontMatter,"JSON"];
+(*Create the front matter string with "---" delimiters*)
+frontMatterString=StringJoin["\n",frontMatterJSON,"\n\n"];
+(*Append the front matter to the input string*)
+resultString=StringJoin[frontMatterString,markdownString];
+(*Return the result*)
+resultString,
+(*Return plain markdown string *)
+markdownString]
+]
+
+
+(* ::Section:: *)
 (*ToImageElement*)
 
 
@@ -430,7 +450,7 @@ parseData[ TemplateBox[{lbl_, ref_}, "RefLink"|"RefLinkPlain"|"StringTypeLink", 
 ]:= MDElement["Hyperlink", lbl, "https://reference.wolfram.com/language/" <> StringTrim[ref, "paclet:"]]
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*defaults*)
 
 
@@ -505,7 +525,7 @@ MDElement[args___]:= ( Message[MDElement::unknownTag, args]; "");
 
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*loading*)
 
 

--- a/Tests/Basic.m
+++ b/Tests/Basic.m
@@ -22,6 +22,56 @@ VerificationTest[  M2MD @ "string", "string", TestID -> "String"]
 
 
 (* ::Subsection:: *)
+(*FrontMatter*)
+
+
+
+path = CreateFile[];
+testExport = Import[
+MDExport[path, Cell["Test", "Title"],##],"String"]&;
+
+
+VerificationTest[
+  testExport["FrontMatter" -> <||>]
+, "# Test"
+, TestID -> "front matter: empty -> none"
+]
+
+
+VerificationTest[
+  testExport[]
+, "# Test"
+, TestID -> "no front matter"
+]
+
+
+VerificationTest[
+  testExport["FrontMatter" -> <|"title"->"CODE"|>]
+, "{\r\n\t\"title\":\"CODE\"\r\n}\r\n# Test"
+, TestID -> "simple json front matter"
+]
+
+
+VerificationTest[
+  testExport["FrontMatter" -> $Failed]
+, "# Test"
+, {MDExport::fmerr}
+, TestID -> "unknown front matter"
+]
+
+
+VerificationTest[
+  testExport["FrontMatter" -> "---\ntitle: The Title\n---\n"]
+, "---\r\ntitle: The Title\r\n---\r\n\r\n# Test"
+, TestID -> "custom front matter string"
+]
+
+
+DeleteFile @ path;
+Remove @ path;
+
+
+(* ::Subsection:: *)
 (*Image*)
 
 


### PR DESCRIPTION
Add `AddFrontMatter` function, if `FrontMatter` in `Options` of `MDExport` is not empty, the front matter as `json` (because YAML or toml format is not supported by default in Wolfram language) format will be added to the markdown file output. This feature only works for MDExport, not M2MD

---

- Sorry if I did something wrong or messed up your code, please help me fix them.

- I use your package to export Mathematica to Hugo markdown file, which is why I need a front matter feature.

- If don't add FrontMatter options, the MDExport function will work like normal. If added, it will give results like this.

![image](https://github.com/kubaPod/M2MD/assets/69144096/154998c5-088a-4899-b056-8090b6555437)


